### PR TITLE
fix(analytics): bake PostHog key into thehelper.ca client build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build React SPA
         env:
           REACT_APP_API_URL: https://api.thehelper.ca
+          # Public PostHog project key (phc_…) for the shared Social-Dots project.
+          # Safe to expose — it ships in the client bundle. Inlined by Vite at build time.
+          REACT_APP_POSTHOG_KEY: phc_AxYiacGAymmuaa2cRPMZASTbXRMsiKtdzKv9BiaELZrj
         run: npx vite build --outDir deploy/dist
 
       - name: Commit build artifacts to git

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -8,12 +8,15 @@
 set -e
 
 API_URL="${REACT_APP_API_URL:-https://thehelper.ca}"
+# PostHog public project key (phc_…) is safe to bake into the client bundle.
+# Shared "Social-Dots" PostHog project. Override via env if it ever changes.
+POSTHOG_KEY="${REACT_APP_POSTHOG_KEY:-phc_AxYiacGAymmuaa2cRPMZASTbXRMsiKtdzKv9BiaELZrj}"
 
 echo "Building Wasp server artifacts..."
 wasp build
 
-echo "Building React SPA (API_URL=$API_URL)..."
-REACT_APP_API_URL="$API_URL" npx vite build --outDir deploy/dist
+echo "Building React SPA (API_URL=$API_URL, POSTHOG_KEY=${POSTHOG_KEY:0:8}…)..."
+REACT_APP_API_URL="$API_URL" REACT_APP_POSTHOG_KEY="$POSTHOG_KEY" npx vite build --outDir deploy/dist
 
 # === Bundle guard: catch the "wrong REACT_APP_API_URL" class of bug. ===
 # If someone rebuilds the bundle with the wrong env var, the deployed
@@ -34,6 +37,15 @@ if ! grep -q "REACT_APP_API_URL:\"$API_URL\"" "$BUNDLE"; then
   exit 1
 fi
 echo "Bundle guard: OK (REACT_APP_API_URL=$API_URL)"
+
+# === Bundle guard: ensure the PostHog key was baked in. ===
+# Without this, thehelper.ca silently sends zero analytics to PostHog.
+if ! grep -q "$POSTHOG_KEY" "$BUNDLE"; then
+  echo "ERROR: bundle is missing the PostHog key ($POSTHOG_KEY)." >&2
+  echo "  re-run with: REACT_APP_POSTHOG_KEY=$POSTHOG_KEY ./deploy/build.sh" >&2
+  exit 1
+fi
+echo "Bundle guard: OK (REACT_APP_POSTHOG_KEY baked in)"
 
 echo ""
 echo "Done. Stage, commit, and push:"


### PR DESCRIPTION
## Problem
`thehelper.ca` sends **zero** events to PostHog. The PostHog project (shared "Social-Dots", key `phc_AxYi…`) receives data from socialdots.ca and chicplates.com but nothing from the helper.

Root cause: PostHog is correctly wired in `src/client/App.tsx` (inits only when `import.meta.env.REACT_APP_POSTHOG_KEY` is set), but **neither deploy path passed that var to `vite build`**, so Vite never inlined it. The production bundle in `deploy/dist` contains no PostHog reference. Verified live: no requests to `us.i.posthog.com`.

## Fix
- **`.github/workflows/deploy.yml`** (authoritative deploy on push to `main`): add `REACT_APP_POSTHOG_KEY` to the "Build React SPA" step. It's the public `phc_` key — safe to expose; it ships in the bundle.
- **`deploy/build.sh`** (manual builds): pass the key to `vite build` and add a bundle guard mirroring the existing `REACT_APP_API_URL` guard.

`REACT_APP_API_URL` is intentionally left unchanged.

## After merge
CI rebuilds the SPA (now with the key), redeploys to the VPS, and purges Cloudflare. Then `thehelper.ca` will report into the shared PostHog project and I'll add its per-site dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)